### PR TITLE
Bump prometheus version to 8.15.1

### DIFF
--- a/jx-app-prometheus/requirements.yaml
+++ b/jx-app-prometheus/requirements.yaml
@@ -2,4 +2,4 @@
 dependencies:
 - name: "prometheus"
   repository: "@stable"
-  version: 8.10.3
+  version: 8.15.1


### PR DESCRIPTION
There is an even newer version as well, but this is latest without a major version bump.

It adds the ability to declare extra volume mounts, which would be useful to me, plus whatever else has been fixed.

Renovate bot could keep all these up to date for you, FYI